### PR TITLE
Cards in collections render on details page

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -8,13 +8,13 @@ import { CollectionDetail } from "./collections/CollectionDetail"
 export const ApplicationViews = () => {
     return (
         <>
-            <Route path="/collections">
+            <Route exact path="/collections">
                 <CollectionList />
             </Route>
-            <Route path="/collectionform">
+            <Route exact path="/collectionform">
                 <CollectionForm />
             </Route>
-            <Route path="/collectiondetail">
+            <Route exact path="/collections/:collectionId(\d+)">
                 <CollectionDetail />
             </Route>
 

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -2,6 +2,8 @@ import React from "react"
 import { Route } from "react-router-dom"
 import { CollectionList } from "./collections/CollectionList"
 import { CollectionForm } from "./collections/CollectionForm"
+import { CollectionDetail } from "./collections/CollectionDetail"
+
 
 export const ApplicationViews = () => {
     return (
@@ -11,6 +13,9 @@ export const ApplicationViews = () => {
             </Route>
             <Route path="/collectionform">
                 <CollectionForm />
+            </Route>
+            <Route path="/collectiondetail">
+                <CollectionDetail />
             </Route>
 
         </>

--- a/src/components/collections/CollectionDetail.js
+++ b/src/components/collections/CollectionDetail.js
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from "react"
+import { useHistory } from "react-router-dom"
+
+
+export const CollectionDetail = () => {
+    return <>
+        <h1>Collection Detail</h1>
+        <div>
+            <button>Add Cards</button>
+        </div>
+        {
+            // collection map
+        }
+        <div>
+            <button>ViewCommetns</button>
+        </div>
+    </>
+}

--- a/src/components/collections/CollectionDetail.js
+++ b/src/components/collections/CollectionDetail.js
@@ -1,16 +1,43 @@
 import React, { useEffect, useState } from "react"
+import { useParams } from "react-router-dom"
 import { useHistory } from "react-router-dom"
+import { getSingleCollection } from "./CollectionManager"
 
 
 export const CollectionDetail = () => {
+    const [collection, setCollection] = useState({})
+    const { collectionId } = useParams()
+    const parsedId = parseInt(collectionId)
+    useEffect(() => {
+        getSingleCollection(parsedId).then(setCollection)
+    }, [])
+    
+    console.log(parsedId)
     return <>
         <h1>Collection Detail</h1>
         <div>
             <button>Add Cards</button>
         </div>
-        {
-            // collection map
-        }
+        <div>
+            {
+                collection.card?.map((card) => {
+                    return <>
+                    <img key={`card--${card.id}`}src={card.image} />
+                    <p>{card.first_name} {card.last_name}</p>
+                    <p>Card #{card.card_number}</p>
+                    <p>Category: {card.card_category.label}</p>
+                    <p>Set: {card.set?.name}</p>
+                    <ul>Attributes: 
+                    {
+                        card.tag.map((cardtags) => {
+                            return <li key={`cardtags--${cardtags.id}`}>{cardtags.label}</li>
+                        })
+                    }
+                    </ul>
+                    </>
+                })
+            }
+        </div>
         <div>
             <button>ViewCommetns</button>
         </div>

--- a/src/components/collections/CollectionList.js
+++ b/src/components/collections/CollectionList.js
@@ -19,7 +19,7 @@ export const CollectionList = () => {
                     return <>
                         <h1 key={`c--${c.id}`}>{c.name}</h1>
                         <div>
-                            <Link to={'/collectiondetail'}>View</Link>
+                            <Link to={`/collections/${c.id}`}>View</Link>
                             <button>Delete</button>
                         </div>
                     </>

--- a/src/components/collections/CollectionList.js
+++ b/src/components/collections/CollectionList.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react"
 import { getCollections } from "./CollectionManager"
-import { useHistory } from "react-router-dom"
+import { useHistory, Link } from "react-router-dom"
 
 
 export const CollectionList = () => {
@@ -19,7 +19,7 @@ export const CollectionList = () => {
                     return <>
                         <h1 key={`c--${c.id}`}>{c.name}</h1>
                         <div>
-                            <button>View</button>
+                            <Link to={'/collectiondetail'}>View</Link>
                             <button>Delete</button>
                         </div>
                     </>

--- a/src/components/collections/CollectionManager.js
+++ b/src/components/collections/CollectionManager.js
@@ -7,6 +7,15 @@ export const getCollections = () => {
     .then(res => res.json())
 }
 
+export const getSingleCollection = (id) => {
+    return fetch(`http://localhost:8000/collections/${id}`, {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    })
+    .then(res => res.json())
+}
+
 export const createCollection = (newCollection) => {
     
     const fetchOptions = {


### PR DESCRIPTION
# Description

cards in collections render on collection details page

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

as a logged in user, navigate to you collections via the navbar
click on one the collections view links to got to the details page
all the cards in that collection should be rendered on the DOM


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings