### PR TITLE
sets list and detail pages render

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -3,6 +3,8 @@ import { Route } from "react-router-dom"
 import { CollectionList } from "./collections/CollectionList"
 import { CollectionForm } from "./collections/CollectionForm"
 import { CollectionDetail } from "./collections/CollectionDetail"
+import { SetList } from "./sets/SetList"
+import { SetDetail } from "./sets/SetDetail"
 
 
 export const ApplicationViews = () => {
@@ -16,6 +18,12 @@ export const ApplicationViews = () => {
             </Route>
             <Route exact path="/collections/:collectionId(\d+)">
                 <CollectionDetail />
+            </Route>
+            <Route exact path="/sets">
+                <SetList />
+            </Route>
+            <Route exact path="/sets/:setId(\d+)">
+                <SetDetail />
             </Route>
 
         </>

--- a/src/components/sets/SetDetail.js
+++ b/src/components/sets/SetDetail.js
@@ -1,0 +1,10 @@
+import React, { useEffect, useState } from "react"
+import { getSets } from "./SetManager"
+import { useHistory, Link } from "react-router-dom"
+
+
+export const SetDetail = () => {
+    return (
+        <h1>Set Details</h1>
+    )
+}

--- a/src/components/sets/SetList.js
+++ b/src/components/sets/SetList.js
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from "react"
+import { getSets } from "./SetManager"
+import { useHistory, Link } from "react-router-dom"
+
+
+export const SetList = () => {
+    const [sets, setSets] = useState([])
+
+    useEffect(() => {
+        getSets().then(setSets)
+    }, [])
+
+    return (
+        <>
+            <h1>Sets</h1>
+            { // mapping over the sets array for individual set info
+                sets.map((set) => {
+                    return <> 
+                    <Link to={`/sets/${set.id}`}><p>{set.name}</p></Link>
+                    </>
+                })
+            }
+        </>
+    )
+}

--- a/src/components/sets/SetManager.js
+++ b/src/components/sets/SetManager.js
@@ -1,0 +1,17 @@
+export const getSets = () => {
+    return fetch("http://localhost:8000/sets", {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    })
+    .then(res => res.json())
+}
+
+export const getSingleSet = (id) => {
+    return fetch(`http://localhost:8000/sets/${id}`, {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    })
+    .then(res => res.json())
+}


### PR DESCRIPTION
# Description

add routes and defined components for a sets list page and sets detail page

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

as a logged in user, navigate to the sets page via the navbar
the should be a list of sets displayed as links
click on a link
the url at the top should change to /sets/{that sets id}
and a Set Details in <h1> should be displayed at the top of the page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings