### PR TITLE
card details page and functionality to add card to collection

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -6,6 +6,7 @@ import { CollectionDetail } from "./collections/CollectionDetail"
 import { SetList } from "./sets/SetList"
 import { SetDetail } from "./sets/SetDetail"
 import { CardForm } from "./cards/CardForm"
+import { CardDetail } from "./cards/CardDetail"
 
 
 export const ApplicationViews = () => {
@@ -28,6 +29,9 @@ export const ApplicationViews = () => {
             </Route>
             <Route exact path="/cardform/:setId(\d+)">
                 <CardForm />
+            </Route>
+            <Route exact path="/carddetail/:cardId(\d+)">
+                <CardDetail />
             </Route>
 
         </>

--- a/src/components/cardcollection/CardCollectionManager.js
+++ b/src/components/cardcollection/CardCollectionManager.js
@@ -1,0 +1,31 @@
+export const getCardCollections = () => {
+    return fetch("http://localhost:8000/cardcollections", {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    })
+    .then(res => res.json())
+}
+
+export const createCardCollection = (newCard) => {
+    
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`,
+            "content-Type": "application/json"
+        },
+        body: JSON.stringify(newCard)
+    }
+    return fetch(`http://localhost:8000/cardcollections`, fetchOptions)
+
+}
+
+export const deleteCardCollection = (id) => {
+    return fetch (`http://localhost:8000/cardcollections/${id}`, {
+        method: "DELETE",
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    }).then(getCardCollections)
+};

--- a/src/components/cards/CardDetail.js
+++ b/src/components/cards/CardDetail.js
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, Link, useParams } from "react-router-dom"
+import { getCollections, getSingleCollection } from "../collections/CollectionManager"
+import { getSingleCard } from "./CardManager"
+import { createCardCollection, getCardCollections } from "../cardcollection/CardCollectionManager"
+
+
+
+export const CardDetail = () => {
+    const [card, setCard] = useState({})
+    const [collections, setCollections] = useState([])
+    const [collectionId, setCollectionId] = useState(0)
+    const [collection, setCollection] = useState({})
+    const [cardCollections, setCardCollections] = useState([])
+
+    const { cardId } = useParams()
+    const parsedId = parseInt(cardId)
+    const history = useHistory()
+
+    // gets a single card based on the id in the URL
+    useEffect(() => {
+        getSingleCard(parsedId).then(setCard)
+    }, [])
+
+    // gets the collections array
+    useEffect(() => {
+        getCollections().then(setCollections)
+    }, [])
+
+    // gets the collection object selected from below
+    useEffect(() => {
+        getSingleCollection(collectionId).then(setCollection)
+    }, [collectionId])
+
+    // gets everything in the cardcollections table
+    useEffect(() => {
+        getCardCollections().then(setCardCollections)
+    }, [])
+
+    // checks to see if the card selected is already in the card array of that collection
+    const found = 
+        collection.card?.find(c => c.id === parsedId)
+    
+    
+    const addCardToCollection = (e) => {
+        e.preventDefault()
+        // this is the object being sent to the cardcollection array
+        const newCard = {
+            card: parsedId,
+            collection: collectionId
+        }
+        // if there is nothing in the card array of the collection object OR if nothing is returned from the .find above (found variable)
+        if (collection.card?.length === 0 || !found) {
+            createCardCollection(newCard).then(history.push('/sets'))
+        // if the .find above does return an object and that id is the same as the card id (id from the URL)
+        } else if (found.id === parsedId) {
+            window.alert("Card already exists in collection")}
+            
+    }
+
+    return (
+        <>
+            <h1>Detail</h1>
+            <section>
+                <p>{card.first_name} {card.last_name}</p>
+                <p>Card #{card.card_number}</p>
+                <p>Attributes:
+                    {
+                        card.tag?.map((tag) => {
+                            return <>
+                                <span> {tag.label} </span>
+                            </>
+                        })
+                    }
+                </p>
+                <img src={`http://localhost:8000${card.image}`} className="image is-128x128 mr-3"></img>
+                <div>
+                    <select onChange={(evt) => {
+                        let copy = { ...collectionId }
+                        copy = evt.target.value
+                        setCollectionId(copy)
+                    }
+                    }>
+                        <option>Choose Collection</option>
+                        {
+                            collections.map((c) => {
+                                return <option value={c.id}>{c.name}</option>
+                            })
+                        }
+                    </select>
+                    <button onClick={addCardToCollection}>Add</button>
+                </div>
+
+            </section>
+        </>
+    )
+}

--- a/src/components/cards/CardManager.js
+++ b/src/components/cards/CardManager.js
@@ -30,3 +30,17 @@ export const createCard = (newCard) => {
         .then(getCards)
 
 }
+
+export const createCardCollection = (newCard) => {
+    
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`,
+            "content-Type": "application/json"
+        },
+        body: JSON.stringify(newCard)
+    }
+    return fetch(`http://localhost:8000/cardcollections`, fetchOptions)
+
+}

--- a/src/components/collections/CollectionDetail.js
+++ b/src/components/collections/CollectionDetail.js
@@ -8,6 +8,7 @@ export const CollectionDetail = () => {
     const [collection, setCollection] = useState({})
     const { collectionId } = useParams()
     const parsedId = parseInt(collectionId)
+    const history = useHistory()
     
     useEffect(() => {
         getSingleCollection(parsedId).then(setCollection)
@@ -16,14 +17,13 @@ export const CollectionDetail = () => {
     return <>
         <h1>Collection Detail</h1>
         <div>
-            <button>Add Cards</button>
+            <button onClick={() => {history.push('/sets')}}>Add Cards</button>
         </div>
         <div>
             {   // mapping over the card array in the collection object
                 collection.card?.map((card) => {
                     return <>
-                    <img key={`card--${card.id}`} src={card.image} />
-                    <p>{card.first_name} {card.last_name}</p>
+                    <img src={`http://localhost:8000${card.image}`} className="image is-128x128 mr-3"></img>                    <p>{card.first_name} {card.last_name}</p>
                     <p>Card #{card.card_number}</p>
                     <p>Category: {card.card_category.label}</p>
                     <p>Set: {card.set?.name}</p>
@@ -34,6 +34,9 @@ export const CollectionDetail = () => {
                         })
                     }
                     </ul>
+                    <div>
+                    <button>Remove Card</button>
+                    </div>
                     </>
                 })
             }

--- a/src/components/collections/CollectionManager.js
+++ b/src/components/collections/CollectionManager.js
@@ -39,3 +39,15 @@ export const deleteCollection = (id) => {
         }
     }).then(getCollections)
 };
+
+export const updateCollection = (collection, id) => {
+    return fetch(`http://localhost:8000/collections/${id}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        },
+        body: JSON.stringify(collection)
+    })
+        .then(getCollections)
+}

--- a/src/components/sets/SetDetail.js
+++ b/src/components/sets/SetDetail.js
@@ -35,40 +35,13 @@ export const SetDetail = () => {
 
     return ( <> 
         <h1>Set Details</h1>
-        <button onClick={()=>{history.push(`/cardform/${set.id}`)}}>Add Card To Set</button>
+        {/* <button onClick={()=>{history.push(`/cardform/${set.id}`)}}>Add Card To Set</button> */}
         {
             cards.map((card) => {
-                if (card.set.id == parsedId) {
-                    return <>
-                    <p>{card.first_name} {card.last_name}</p>
-                    <p>Card No. {card.card_number}</p>
-                    <p>Attributes:  
-                    {
-                        card.tag.map((tag) => {
-                            return <>
-                            <span> {tag.label} </span> 
-                            </>
-                        })
-                    }
-                    </p>
-                    <img src={`http://localhost:8000${card.image}`} className="image is-128x128 mr-3"></img>
-                    <div>
-
-                    <select onChange={() => {
-                        
-                    }
-                }>
-                    <option>Choose Collection</option>
-                    {
-                        collection.map((c) => {
-                            return <option value={c.id}>{c.name}</option>
-                        })
-                    }
-                    </select>
-                    <button>Add</button>
-                    <button onClick={() => {deleteCard(card.id).then(setCards)}}>Delete Card</button>
-                    </div>
-                    </>
+                if (card.set.id === parsedId) {
+                    return <ul>
+                        <li>#{card.card_number} <Link to={`/carddetail/${card.id}`}>{card.first_name} {card.last_name}</Link></li>
+                    </ul>
                 }
             })
         }


### PR DESCRIPTION
# Description

added fetch calls for the cardcollection table
added ability to add card to collection from the card details page
cleaned up setDetails page to just a list with card number and name as a Link

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Log in as a registered user
navigate to the collections page
create collection if you dont already have one or view an existing collection
click on add card button
choose a set
choose a card
from the drop down select the collection you want to add the card to
click add button
if card is not already in the collection, it will be added
if not, a window alert will appear telling you its already in collection
navigate back to collection to verify card was added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings