### PR TITLE
added create, read, and delete functionality for collection comments

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -7,6 +7,8 @@ import { SetList } from "./sets/SetList"
 import { SetDetail } from "./sets/SetDetail"
 import { CardForm } from "./cards/CardForm"
 import { CardDetail } from "./cards/CardDetail"
+import { CommentList } from "./comments/CommentList"
+import { CommentForm } from "./comments/CommentForm"
 
 
 export const ApplicationViews = () => {
@@ -32,6 +34,12 @@ export const ApplicationViews = () => {
             </Route>
             <Route exact path="/carddetail/:cardId(\d+)">
                 <CardDetail />
+            </Route>
+            <Route exact path="/comments/:collectionId(\d+)">
+                <CommentList />
+            </Route>
+            <Route exact path="/commentform/:collectionId(\d+)">
+                <CommentForm />
             </Route>
 
         </>

--- a/src/components/collections/CollectionDetail.js
+++ b/src/components/collections/CollectionDetail.js
@@ -42,7 +42,7 @@ export const CollectionDetail = () => {
             }
         </div>
         <div>
-            <button>ViewCommetns</button>
+            <button onClick={() => {history.push(`/comments/${parsedId}`)}}>ViewCommetns</button>
         </div>
     </>
 }

--- a/src/components/comments/CommentForm.js
+++ b/src/components/comments/CommentForm.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, useParams } from "react-router-dom"
+import { getCurrentUser } from "../users/UserManager"
+import { createCollectionComments, getCollectionComments } from "./CommentManager"
+
+
+export const CommentForm = () => {
+    const [currentUser, setCurrentUser] = useState({})
+
+    const { collectionId } = useParams()
+    const parsedId = collectionId
+    const history = useHistory()
+    const date = new Date()
+
+    const [comment, setComment] = useState({
+        content: "",
+        date: date.toISOString().split('T')[0],
+        posted_by: 0,
+        collection: 0,
+    })
+
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
+    }, [])
+
+    const submitComment = (e) => {
+        e.preventDefault()
+        const newComment = {
+            content: comment.content,
+            date: comment.date,
+            posted_by: currentUser,
+            collection: parsedId
+        }
+        createCollectionComments(newComment).then(history.push(`/comments/${parsedId}`))
+    }
+
+    console.log(currentUser)
+
+    return (
+        <>
+            <h1>Comment Form</h1>
+            <label>New Comment? </label>
+            <input
+                type="text"
+                placeholder="type comment here"
+                onChange={(e) => {
+                    const copy = { ...comment }
+                    copy.content = e.target.value
+                    setComment(copy)
+                }} />
+            <button onClick={submitComment}>Submit Comment</button>
+        </>
+    )
+}

--- a/src/components/comments/CommentList.js
+++ b/src/components/comments/CommentList.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, Link } from "react-router-dom"
+import { useParams } from "react-router-dom/cjs/react-router-dom.min"
+import { deleteCollectionComments, getCollectionComments } from "./CommentManager"
+
+
+export const CommentList = () => {
+    const [comments, setComments] = useState([])
+
+    const { collectionId } = useParams()
+    const parsedId = collectionId
+    const history = useHistory()
+
+    useEffect(() => {
+        getCollectionComments().then(setComments)
+    }, [])
+
+    return (
+        <>
+            <h1>Comments</h1>
+            <button onClick={() => { history.push(`/commentform/${parsedId}`) }}>Add Comment</button>
+            {
+                comments.map((comment) => {
+                    return <>
+                        <ul>
+                            <li>{comment.content}</li>
+                            <li>Posted on: {comment.date}</li>
+                            <li>Posted by: {comment.posted_by?.username}</li>
+                        </ul>
+                        <button onClick={() => {deleteCollectionComments(comment.id).then(setComments)}}>Delete Comment</button>
+                    </>
+                })
+            }
+        </>
+    )
+}

--- a/src/components/comments/CommentManager.js
+++ b/src/components/comments/CommentManager.js
@@ -1,0 +1,53 @@
+export const getCollectionComments = () => {
+    return fetch("http://localhost:8000/collectioncomments", {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    })
+    .then(res => res.json())
+}
+
+export const getSingleCollectionComments = (id) => {
+    return fetch(`http://localhost:8000/collectioncomments/${id}`, {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    })
+    .then(res => res.json())
+}
+
+export const createCollectionComments = (newComment) => {
+    
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`,
+            "content-Type": "application/json"
+        },
+        body: JSON.stringify(newComment)
+    }
+    return fetch(`http://localhost:8000/collectioncomments`, fetchOptions)
+        .then(getCollectionComments)
+
+}
+
+export const deleteCollectionComments = (id) => {
+    return fetch (`http://localhost:8000/collectioncomments/${id}`, {
+        method: "DELETE",
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    }).then(getCollectionComments)
+};
+
+export const updateCollectionComments = (comment, id) => {
+    return fetch(`http://localhost:8000/collectioncomments/${id}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        },
+        body: JSON.stringify(comment)
+    })
+        .then(getCollectionComments)
+}


### PR DESCRIPTION
# Description

Added routed for comments and comment form
Add functionality to post, delete, and view, comments

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Login as a registered user
navigate to one of your collections via collections on the nav bar
scroll to bottom and click on view comments, if there are already comments, they will be visable.
click on add comment 
fill out the input field and click submit 
you should be re routed back to the comments list and your comment should be displayed
click on the delete button on your comment and it should be deleted and the DOM should update automatically.
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings