### PR TITLE
added edit functionality on collection comments

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -9,6 +9,7 @@ import { CardForm } from "./cards/CardForm"
 import { CardDetail } from "./cards/CardDetail"
 import { CommentList } from "./comments/CommentList"
 import { CommentForm } from "./comments/CommentForm"
+import { CommentEdit } from "./comments/CommentEdit"
 
 
 export const ApplicationViews = () => {
@@ -40,6 +41,9 @@ export const ApplicationViews = () => {
             </Route>
             <Route exact path="/commentform/:collectionId(\d+)">
                 <CommentForm />
+            </Route>
+            <Route exact path="/editcomment/:commentId(\d+)">
+                <CommentEdit />
             </Route>
 
         </>

--- a/src/components/comments/CommentEdit.js
+++ b/src/components/comments/CommentEdit.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, useParams } from "react-router-dom"
+import { getCurrentUser } from "../users/UserManager"
+import { createCollectionComments, getCollectionComments, getSingleCollectionComments, updateCollectionComments } from "./CommentManager"
+
+
+export const CommentEdit = () => {
+    const history = useHistory()
+    const { commentId } = useParams()
+    const parsedCommentId = parseInt(commentId)
+    const [comment, setComment] = useState({})
+    const [content, setNewContent] = useState("")
+
+    useEffect(() => {
+        getSingleCollectionComments(parsedCommentId).then(setComment)
+    }, [])
+
+    const submitEditedComment = (evt) => {
+        evt.preventDefault()
+        const submitEdit = {
+            content: content,
+            date: comment.date,
+            posted_by: comment.posted_by?.id,
+            collection: comment.collection?.id
+        }
+        updateCollectionComments(submitEdit, parsedCommentId)
+            .then(() => {history.push(`/comments/${comment.collection?.id}`)})
+    }
+    console.log(comment)
+    return (
+        <>
+            <h1>Edit Comment</h1>
+            <div>
+                <textarea
+                    className="textarea"
+                    defaultValue={comment.content}
+                    onChange={
+                        (evt) => {
+                            let copy = { ...content }
+                            copy = evt.target.value
+                            setNewContent(copy)
+                        }}
+                    required autoFocus
+                ></textarea>
+            </div>
+            <div>
+                <button onClick={submitEditedComment}>Save</button>
+            </div>
+        </>
+    )
+}

--- a/src/components/comments/CommentList.js
+++ b/src/components/comments/CommentList.js
@@ -28,6 +28,7 @@ export const CommentList = () => {
                             <li>Posted by: {comment.posted_by?.username}</li>
                         </ul>
                         <button onClick={() => {deleteCollectionComments(comment.id).then(setComments)}}>Delete Comment</button>
+                        <button onClick={() => {history.push(`/editcomment/${comment.id}`)}}>Edit Comment</button>
                     </>
                 })
             }


### PR DESCRIPTION
# Description

added ability to edit your own comments on collections

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

login as a registered user
navigate to collections via the navbar
scroll down to view comments
make a comment if you don't have any
click on the edit comment button
change something in the textarea and click save
you should be re routed back to the comments list and your comment should be updated

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings