### PR TITLE
added ability for admins to add and edit sets

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -10,6 +10,8 @@ import { CardDetail } from "./cards/CardDetail"
 import { CommentList } from "./comments/CommentList"
 import { CommentForm } from "./comments/CommentForm"
 import { CommentEdit } from "./comments/CommentEdit"
+import { SetForm } from "./sets/SetForm"
+import { SetEdit } from "./sets/SetEdit"
 
 
 export const ApplicationViews = () => {
@@ -44,6 +46,12 @@ export const ApplicationViews = () => {
             </Route>
             <Route exact path="/editcomment/:commentId(\d+)">
                 <CommentEdit />
+            </Route>
+            <Route exact path="/setform">
+                <SetForm />
+            </Route>
+            <Route exact path="/setedit/:setId(\d+)">
+                <SetEdit />
             </Route>
 
         </>

--- a/src/components/sets/SetEdit.js
+++ b/src/components/sets/SetEdit.js
@@ -10,15 +10,13 @@ export const SetEdit = () => {
         manufacturer: "",
         year: ""
     })
-    // const [ name, setName ] = useState("")
-    // const [ manufacturer, setManufacturer ] = useState("")
-    // const [ year, setYear ] = useState("")
-
-
+    
     const { setId } = useParams()
     const parsedId = setId
     const history = useHistory()
 
+    // this is fetching the current set and setting the values of the keys in the above
+    // state variable to values of the current set
     useEffect(() => {
         getSingleSet(parsedId).then((newSet) => {
             setSingleSet({

--- a/src/components/sets/SetEdit.js
+++ b/src/components/sets/SetEdit.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, useParams } from "react-router-dom"
+import { getSingleSet, updateSet } from "./SetManager"
+
+
+export const SetEdit = () => {
+
+    const [singleSet, setSingleSet] = useState({
+        name: "",
+        manufacturer: "",
+        year: ""
+    })
+    // const [ name, setName ] = useState("")
+    // const [ manufacturer, setManufacturer ] = useState("")
+    // const [ year, setYear ] = useState("")
+
+
+    const { setId } = useParams()
+    const parsedId = setId
+    const history = useHistory()
+
+    useEffect(() => {
+        getSingleSet(parsedId).then((newSet) => {
+            setSingleSet({
+                name: newSet.name,
+                manufacturer: newSet.manufacturer,
+                year: newSet.year
+            })
+        })
+    }, [])
+
+    const saveEditedSet = (e) => {
+        e.preventDefault()
+        const editedSet = {
+            name: singleSet.name,
+            manufacturer: singleSet.manufacturer,
+            year: singleSet.year
+        }
+        updateSet(editedSet, parsedId)
+            .then(() => { history.push("/sets") })
+    }
+
+    return (
+        <>
+            <h1>Set Edit Form</h1>
+            <form>
+                <div>
+                    <label>Name: </label>
+                    <input
+                        type="text"
+                        value={singleSet.name}
+                        onChange={(evt) => {
+                            const copy = { ...singleSet }
+                            copy.name = evt.target.value
+                            setSingleSet(copy)
+                        }} />
+                </div>
+                <div>
+                    <label>Manufacturer: </label>
+                    <input
+                        type="text"
+                        value={singleSet.manufacturer}
+                        onChange={(evt) => {
+                            const copy = { ...singleSet }
+                            copy.manufacturer = evt.target.value
+                            setSingleSet(copy)
+                        }} />
+                </div>
+                <div>
+                    <label>Year: </label>
+                    <input
+                        type="text"
+                        defaultValue={singleSet.year}
+                        onChange={(evt) => {
+                            const copy = { ...singleSet }
+                            copy.year = evt.target.value
+                            setSingleSet(copy)
+                        }} />
+                </div>
+                <div>
+                    <button onClick={saveEditedSet}>Save Set</button>
+                    <button onClick={() => { history.push("/sets") }}>Cancel</button>
+                </div>
+            </form>
+
+        </>
+    )
+}

--- a/src/components/sets/SetForm.js
+++ b/src/components/sets/SetForm.js
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, Link, useParams } from "react-router-dom"
+import { createSet } from "./SetManager"
+
+
+
+export const SetForm = () => {
+    const [newSet, setNewSet] = useState({
+        name: "",
+        manufacturer: "",
+        year: ""
+    })
+    const history = useHistory()
+
+    const createNewSet = (e) => {
+        e.preventDefault()
+        const setForSubmit = {
+            name: newSet.name,
+            manufacturer: newSet.manufacturer,
+            year: newSet.year
+        }
+        createSet(setForSubmit).then(history.push("/sets"))
+    }
+
+    return (
+        <>
+            <h1>Set Form</h1>
+            <form>
+                <div>
+                    <label>Name: </label>
+                    <input
+                        type="text"
+                        onChange={(evt) => {
+                            const copy = { ...newSet }
+                            copy.name = evt.target.value
+                            setNewSet(copy)
+                        }} />
+                </div>
+                <div>
+                    <label>Manufacturer: </label>
+                    <input
+                        type="text"
+                        onChange={(evt) => {
+                            const copy = { ...newSet }
+                            copy.manufacturer = evt.target.value
+                            setNewSet(copy)
+                        }} />
+                </div>
+                <div>
+                    <label>Year: </label>
+                    <input
+                        type="text"
+                        onChange={(evt) => {
+                            const copy = { ...newSet }
+                            copy.year = evt.target.value
+                            setNewSet(copy)
+                        }} />
+                </div>
+                <div>
+                    <button onClick={createNewSet}>Save Set</button>
+                </div>
+            </form>
+        </>
+    )
+}

--- a/src/components/sets/SetList.js
+++ b/src/components/sets/SetList.js
@@ -1,22 +1,39 @@
 import React, { useEffect, useState } from "react"
 import { getSets } from "./SetManager"
 import { useHistory, Link } from "react-router-dom"
+import { getCurrentUser } from "../users/UserManager"
 
 
 export const SetList = () => {
     const [sets, setSets] = useState([])
+    const [currentUser, setCurrentUser] = useState({})
+    const history = useHistory()
 
     useEffect(() => {
         getSets().then(setSets)
     }, [])
 
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
+    }, [])
+
     return (
         <>
             <h1>Sets</h1>
+            { //checking to see if the current user is an admin, if so, they will see the button
+            currentUser.is_staff 
+                ? <button onClick={() => {history.push("/setform")}}>Add New Set</button>
+                : ""
+            }
             { // mapping over the sets array for individual set info
                 sets.map((set) => {
                     return <> 
                     <Link to={`/sets/${set.id}`}><p>{set.name}</p></Link>
+                    {
+                        currentUser.is_staff
+                            ? <button onClick={() => {history.push(`/setedit/${set.id}`)}}>Edit</button>
+                            : ""
+                    }
                     </>
                 })
             }

--- a/src/components/sets/SetManager.js
+++ b/src/components/sets/SetManager.js
@@ -26,3 +26,28 @@ export const deleteCard = (id) => {
         }
     }).then(getCards)
 };
+
+export const createSet = (newSet) => {
+    
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`,
+            "content-Type": "application/json"
+        },
+        body: JSON.stringify(newSet)
+    }
+    return fetch(`http://localhost:8000/sets`, fetchOptions)
+
+}
+
+export const updateSet = (set, id) => {
+    return fetch(`http://localhost:8000/sets/${id}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        },
+        body: JSON.stringify(set)
+    })
+}


### PR DESCRIPTION
# Description

admins can add and edit sets to the database

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

log in as a registered admin
navigate to the sets page via the navbar
there should be a button to add a new set at the top of the page
and any already existing sets should have an edit button
click on add a set button and fill out fields 
click submit and you should be re routed back to the sets page with your new set being displayed
click on edit set button
change something on one or all of the fields and click save
again, you should be re re rerouted back to the sets page and the changes should be reflected

login as a collector 
navigate to the sets page
there should be no buttons visible



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings