### PR TITLE
collectors can submit cards for approval, admins can approve cards

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -12,6 +12,7 @@ import { CommentForm } from "./comments/CommentForm"
 import { CommentEdit } from "./comments/CommentEdit"
 import { SetForm } from "./sets/SetForm"
 import { SetEdit } from "./sets/SetEdit"
+import { CardApproval } from "./cardapproval/CardApprovalList"
 
 
 export const ApplicationViews = () => {
@@ -52,6 +53,9 @@ export const ApplicationViews = () => {
             </Route>
             <Route exact path="/setedit/:setId(\d+)">
                 <SetEdit />
+            </Route>
+            <Route exact path="/approval">
+                <CardApproval />
             </Route>
 
         </>

--- a/src/components/cardapproval/CardApprovalList.js
+++ b/src/components/cardapproval/CardApprovalList.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from "react"
+import { Link, useHistory } from "react-router-dom"
+import { getCards } from "../cards/CardManager"
+import { approveCard } from "../cards/CardManager"
+
+
+export const CardApproval = () => {
+    const [ cards, setCards ] = useState([])
+
+    useEffect(() => {
+        getCards().then(setCards)
+    }, [])
+
+    return (
+        <>
+        <h1>Cards That Need Approval</h1>
+        {
+            cards.map((card) => {
+                return <>
+                {
+                card.is_approved
+                    ? ""
+                    : <ul>
+                        <li>{card.first_name} {card.last_name} <button onClick={() => {approveCard(card.id).then(setCards)}}>Approve</button></li>
+                    </ul> 
+                    }
+            </>
+            })
+        }
+        </>
+    )
+}

--- a/src/components/cards/CardManager.js
+++ b/src/components/cards/CardManager.js
@@ -44,3 +44,13 @@ export const createCardCollection = (newCard) => {
     return fetch(`http://localhost:8000/cardcollections`, fetchOptions)
 
 }
+
+export const approveCard = (cardId) => {
+    return fetch(`http://localhost:8000/cards/${cardId}/approve`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    }).then(getCards)
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -1,11 +1,19 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { Link, useHistory } from "react-router-dom"
+import { getCurrentUser } from "../users/UserManager"
 // import "./NavBar.css"
 
 export const NavBar = (props) => {
     const history = useHistory()
+    const [currentUser, setCurrentUser] = useState({})
+
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
+    }, [])
+
     return (
         <ul className="navbar">
+            {/* Links for all users */}
             <li className="navbar__item active">
                 <Link className="navbar__link" to="/">Home</Link>
             </li>
@@ -15,6 +23,13 @@ export const NavBar = (props) => {
             <li className="navbar__item active">
                 <Link className="navbar__link" to="/sets">Sets</Link>
             </li>
+            {/* links for only admins */}
+            {
+                currentUser.is_staff
+                    ? <li><Link to="/approval">Cards For Approval</Link></li>
+                    : ""
+            }
+            {/* logout link */}
             {
                 (localStorage.getItem("lu_token") !== null) ?
                     <li className="nav-item">
@@ -33,7 +48,7 @@ export const NavBar = (props) => {
                             <Link className="nav-link" to="/register">Register</Link>
                         </li>
                     </>
-            } 
+            }
         </ul>
     )
 }

--- a/src/components/sets/SetDetail.js
+++ b/src/components/sets/SetDetail.js
@@ -7,7 +7,7 @@ import { getCollections } from "../collections/CollectionManager"
 
 export const SetDetail = () => {
     const [set, setSet] = useState({})
-    const [cards, setCards] =useState([])
+    const [cards, setCards] = useState([])
     const [collection, setCollections] = useState([])
 
     const { setId } = useParams()
@@ -33,19 +33,26 @@ export const SetDetail = () => {
         }
     }
 
-    return ( <> 
+    return (<>
         <h1>Set Details</h1>
-        {/* <button onClick={()=>{history.push(`/cardform/${set.id}`)}}>Add Card To Set</button> */}
+        <button onClick={() => { history.push(`/cardform/${set.id}`) }}>Add Card To Set</button>
         {
             cards.map((card) => {
                 if (card.set.id === parsedId) {
-                    return <ul>
-                        <li>#{card.card_number} <Link to={`/carddetail/${card.id}`}>{card.first_name} {card.last_name}</Link></li>
-                    </ul>
+                    return <>
+                        {
+                            card.is_approved
+                            ?
+                            <ul>
+                                <li>#{card.card_number} <Link to={`/carddetail/${card.id}`}>{card.first_name} {card.last_name}</Link></li>
+                            </ul>
+                            : ""
+                        }
+                    </>
                 }
             })
         }
     </>
-        
+
     )
 }


### PR DESCRIPTION
# Description

collectors can now submit cards for admins to approve, once approved, the card shows up in respective set for collectors to add to collections.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

login as collector and navigate to sets page via navbar
click on a set
click add card to set button
fill out form and click submit
verify that the card does NOT display in the set

login as an admin
navigate to cards for approval page via navbar
that card that the collector just submitted should be displayed in a list
click on the approve button
the list item should disappear
go to the sets page via navbar
click on set link for card that was submitted
the new card should now be displayed in this list
collectors should also see this card in the sets page now as well

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings