### PR TITLE
delete and edit comment privileges 

### DIFF
--- a/src/components/comments/CommentList.js
+++ b/src/components/comments/CommentList.js
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from "react"
 import { useHistory, Link } from "react-router-dom"
 import { useParams } from "react-router-dom/cjs/react-router-dom.min"
+import { getCurrentUser } from "../users/UserManager"
 import { deleteCollectionComments, getCollectionComments } from "./CommentManager"
 
 
 export const CommentList = () => {
     const [comments, setComments] = useState([])
+    const [currentUser, setCurrentUser] = useState({})
 
     const { collectionId } = useParams()
     const parsedId = collectionId
@@ -13,6 +15,10 @@ export const CommentList = () => {
 
     useEffect(() => {
         getCollectionComments().then(setComments)
+    }, [])
+
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
     }, [])
 
     return (
@@ -27,8 +33,18 @@ export const CommentList = () => {
                             <li>Posted on: {comment.date}</li>
                             <li>Posted by: {comment.posted_by?.username}</li>
                         </ul>
-                        <button onClick={() => {deleteCollectionComments(comment.id).then(setComments)}}>Delete Comment</button>
-                        <button onClick={() => {history.push(`/editcomment/${comment.id}`)}}>Edit Comment</button>
+                        
+                        {   //only admins and creators of the comment can delete that comment
+                            currentUser.is_staff || currentUser.id === comment.posted_by?.id
+                                ? <button onClick={() => {deleteCollectionComments(comment.id).then(setComments)}}>Delete Comment</button>
+                                : ""
+                                
+                        }
+                        {   // on users who created comment can edit comment
+                            currentUser.id === comment.posted_by?.id
+                                ? <button onClick={() => {history.push(`/editcomment/${comment.id}`)}}>Edit Comment</button>
+                                : ""
+                        }
                     </>
                 })
             }


### PR DESCRIPTION
# Description

admins can delete any comment, but only edit their own comments, collectors can edit or delete only their comments

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

login as ab admin
navigate to the comments of a collection via the collections page in the navbar
all comments, regardless of author should have the delete button visible
only comments that you have made should also have an edit button

login as a collector
navigate to the comments of a collection via the collections page in the navbar
only comments that you have made should have the delete and edit buttons

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings