### PR TITLE
added back buttons for cards and sets, users see only their collections

### DIFF
--- a/src/components/cards/CardDetail.js
+++ b/src/components/cards/CardDetail.js
@@ -3,6 +3,7 @@ import { useHistory, Link, useParams } from "react-router-dom"
 import { getCollections, getSingleCollection } from "../collections/CollectionManager"
 import { getSingleCard } from "./CardManager"
 import { createCardCollection, getCardCollections } from "../cardcollection/CardCollectionManager"
+import { getCurrentUser } from "../users/UserManager"
 
 
 
@@ -12,6 +13,7 @@ export const CardDetail = () => {
     const [collectionId, setCollectionId] = useState(0)
     const [collection, setCollection] = useState({})
     const [cardCollections, setCardCollections] = useState([])
+    const [currentUser, setCurrentUser] = useState({})
 
     const { cardId } = useParams()
     const parsedId = parseInt(cardId)
@@ -35,6 +37,10 @@ export const CardDetail = () => {
     // gets everything in the cardcollections table
     useEffect(() => {
         getCardCollections().then(setCardCollections)
+    }, [])
+
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
     }, [])
 
     // checks to see if the card selected is already in the card array of that collection
@@ -84,11 +90,20 @@ export const CardDetail = () => {
                         <option>Choose Collection</option>
                         {
                             collections.map((c) => {
-                                return <option value={c.id}>{c.name}</option>
+                                return <>
+                                {
+                                    currentUser.id === c.user?.id    
+                                        ? <option value={c.id}>{c.name}</option>
+                                        : ""
+                                }
+                                </>
                             })
                         }
                     </select>
                     <button onClick={addCardToCollection}>Add</button>
+                </div>
+                <div>
+                    <button onClick={() => {history.push(`/sets/${card.set?.id}`)}}>Back to Cards</button>
                 </div>
 
             </section>

--- a/src/components/collections/CollectionList.js
+++ b/src/components/collections/CollectionList.js
@@ -1,27 +1,39 @@
 import React, { useEffect, useState } from "react"
 import { getCollections, deleteCollection } from "./CollectionManager"
 import { useHistory, Link } from "react-router-dom"
+import { getCurrentUser } from "../users/UserManager"
 
 
 export const CollectionList = () => {
     const [collections, setCollections] = useState([])
+    const [currentUser, setCurrentUser] = useState({})
     const history = useHistory()
 
     useEffect(() => {
         getCollections().then(setCollections)
     }, [])
 
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
+    }, [])
+
     return (
         <>
-            <button onClick={() => {history.push("./collectionform")}}>Add New Collection</button>
+            <button onClick={() => { history.push("./collectionform") }}>Add New Collection</button>
             {
                 collections.map((c) => {
                     return <>
-                        <h1 key={`c--${c.id}`}>{c.name}</h1>
-                        <div>
-                            <Link to={`/collections/${c.id}`}>View</Link>
-                            <button onClick={() => {deleteCollection(c.id).then(setCollections)}}>Delete</button>
-                        </div>
+                        {
+                            currentUser.id === c.user.id
+                                ? <div>
+                                    <h1 key={`c--${c.id}`}>{c.name}</h1>
+                                    <div>
+                                        <Link to={`/collections/${c.id}`}>View</Link>
+                                        <button onClick={() => { deleteCollection(c.id).then(setCollections) }}>Delete</button>
+                                    </div>
+                                </div>
+                                : ""
+                        }
                     </>
                 })
             }

--- a/src/components/sets/SetDetail.js
+++ b/src/components/sets/SetDetail.js
@@ -36,6 +36,7 @@ export const SetDetail = () => {
     return (<>
         <h1>Set Details</h1>
         <button onClick={() => { history.push(`/cardform/${set.id}`) }}>Add Card To Set</button>
+        <button onClick={() => {history.push("/sets")}}>Back to Sets</button>
         {
             cards.map((card) => {
                 if (card.set.id === parsedId) {


### PR DESCRIPTION
# Description

Users can only see their collections on collections page 
Users can only choose their collections when adding cards to collections
added back button for card details and set details pages

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

login as a collector or admin
go to collections page
you should only see collections you've made
login as a different user and repeat steps 2 and 3

click on view collection and click add card
pick a set
pick a card
in the select, only collections you've made should be available to choose.
click the back to cards button
click the back to sets button


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings