### PR TITLE
added an all collections navlink for users to view all collections

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -18,6 +18,7 @@ import { TagForm } from "./tags/TagForm"
 import { TagEdit } from "./tags/TagEdit"
 import { UserList } from "./users/UserList"
 import { UserDetail } from "./users/UserDetail"
+import { AllCollections } from "./collections/AllCollections"
 
 
 export const ApplicationViews = () => {
@@ -31,6 +32,9 @@ export const ApplicationViews = () => {
             </Route>
             <Route exact path="/collections/:collectionId(\d+)">
                 <CollectionDetail />
+            </Route>
+            <Route exact path="/allcollections">
+                <AllCollections />
             </Route>
             <Route exact path="/sets">
                 <SetList />

--- a/src/components/collections/AllCollections.js
+++ b/src/components/collections/AllCollections.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from "react"
+import { getCollections, deleteCollection } from "./CollectionManager"
+import { useHistory, Link } from "react-router-dom"
+import { getCurrentUser } from "../users/UserManager"
+
+
+export const AllCollections = () => {
+    const [collections, setCollections] = useState([])
+    const [currentUser, setCurrentUser] = useState({})
+    const history = useHistory()
+
+    useEffect(() => {
+        getCollections().then(setCollections)
+    }, [])
+
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
+    }, [])
+
+    return (
+        <>
+            {
+                collections.map((c) => {
+                    return <>
+                        {
+                            currentUser.id === c.user.id
+                                ? ""
+                                : <div>
+                                <h1 key={`c--${c.id}`}>{c.name}</h1>
+                                <h3>Owner: <Link to={`user/${c.user?.id}`}>{c.user?.username}</Link></h3>
+                                <div>
+                                    <Link to={`/collections/${c.id}`}>View</Link>
+                                </div>
+                            </div>
+                        }
+                    </>
+                })
+            }
+        </>
+    )
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -21,6 +21,9 @@ export const NavBar = (props) => {
                 <Link className="navbar__link" to="/collections">My Collections</Link>
             </li>
             <li className="navbar__item active">
+                <Link className="navbar__link" to="/allcollections">All Collections</Link>
+            </li>
+            <li className="navbar__item active">
                 <Link className="navbar__link" to="/sets">Sets</Link>
             </li>
             {/* links for only admins */}

--- a/src/components/users/UserDetail.js
+++ b/src/components/users/UserDetail.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from "react"
 import { useHistory, Link } from "react-router-dom"
 import { useParams } from "react-router-dom/cjs/react-router-dom.min"
-import { getUser, getUsers, makeAdmin, makeCollector } from "./UserManager"
+import { getCurrentUser, getUser, getUsers, makeAdmin, makeCollector } from "./UserManager"
 
 export const UserDetail = () => {
     const [user, setUser] = useState({})
+    const [currentUser, setCurrentUser] = useState({})
+    
 
     const { userId } = useParams()
     const parsedId = userId
@@ -12,6 +14,10 @@ export const UserDetail = () => {
     useEffect(() => {
         getUser(parsedId).then(setUser)
     }, [user.is_staff])
+
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
+    }, [])
 
 
 
@@ -31,10 +37,13 @@ export const UserDetail = () => {
                     }
                 </li>
             </ul>
-            {
-                user.is_staff
-                    ? <button onClick={() => {makeCollector(user.id).then(setUser)}}>Make Collector</button>
-                    : <button onClick={() => {makeAdmin(user.id).then(setUser)}}>Make an Admin</button>
+            {   // if the current user is an admin they will see the buttons to promote or demote, regular
+                // users will see no button
+                currentUser.is_staff
+                    ? user.is_staff
+                        ? <button onClick={() => {makeCollector(user.id).then(setUser)}}>Make Collector</button>
+                        : <button onClick={() => {makeAdmin(user.id).then(setUser)}}>Make an Admin</button>
+                    : ""
             }
         </>
     )


### PR DESCRIPTION
# Description

added a navbar link for All Collections where users can see a master list of all other users collections
they can click on the username links to be redirected to that users detail page

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

login as any user
navigate to the all collections page via the navbar
a list of all the collections, except yours, should be displayed
click on the view link to view the cards in that collections
click on the user name to see that users detail page
if the user is an admin the promote/demote button will be visible
if the user is a collector, no button wlll be visible

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings