### PR TITLE
added CRUD for categories, admins only

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -19,6 +19,9 @@ import { TagEdit } from "./tags/TagEdit"
 import { UserList } from "./users/UserList"
 import { UserDetail } from "./users/UserDetail"
 import { AllCollections } from "./collections/AllCollections"
+import { CategoryList } from "./categories/CategoryList"
+import { CategoryForm } from "./categories/CategoryForm"
+import { CategoryEdit } from "./categories/CategoryEdit"
 
 
 export const ApplicationViews = () => {
@@ -80,6 +83,15 @@ export const ApplicationViews = () => {
             </Route>
             <Route exact path="/user/:userId(\d+)">
                 <UserDetail />
+            </Route>
+            <Route exact path="/categories">
+                <CategoryList />
+            </Route>
+            <Route exact path="/categoryform">
+                <CategoryForm />
+            </Route>
+            <Route exact path="/catedit/:catId(\d+)">
+                <CategoryEdit />
             </Route>
 
         </>

--- a/src/components/categories/CategoryEdit.js
+++ b/src/components/categories/CategoryEdit.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, Link } from "react-router-dom"
+import { useParams } from "react-router-dom/cjs/react-router-dom.min"
+import { getCategory, updateCategory } from "./CategoryManager"
+
+
+export const CategoryEdit = () => {
+    const [ category, setCategory ] = useState({})
+    
+    const history = useHistory()
+    const { catId } = useParams()
+    const parsedId = catId
+
+    useEffect(() => {
+        getCategory(parsedId).then(setCategory)
+    }, [])
+
+    const updateNewCategory = (e) => {
+        e.preventDefault()
+        const editedcat = {
+            label: category.label
+        }
+        updateCategory(editedcat, parsedId).then(history.push("/categories"))
+    }
+
+    return (
+        <>
+        <h1>Category Form</h1>
+        <form>
+            <div>
+                <label>Category Label: </label>
+                <input 
+                    type="text"
+                    defaultValue={category.label}
+                    onChange={(e) => {
+                        const copy = { ...category }
+                        copy.label = e.target.value
+                        setCategory(copy)
+                    }} />
+            </div>
+        </form>
+        <button onClick={updateNewCategory}>Save Category</button>
+        </>
+    )
+}

--- a/src/components/categories/CategoryForm.js
+++ b/src/components/categories/CategoryForm.js
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, Link } from "react-router-dom"
+import { createCategory } from "./CategoryManager"
+
+
+export const CategoryForm = () => {
+    const [ newCategory, setCategory ] = useState("")
+    
+    const history = useHistory()
+
+    const createNewCategory = (e) => {
+        e.preventDefault()
+        const cat = {
+            label: newCategory
+        }
+        createCategory(cat).then(history.push("/categories"))
+    }
+
+    return (
+        <>
+        <h1>Category Form</h1>
+        <form>
+            <div>
+                <label>Category Label: </label>
+                <input 
+                    type="text"
+                    onChange={(e) => {
+                        let copy = { ...newCategory }
+                        copy = e.target.value
+                        setCategory(copy)
+                    }} />
+            </div>
+        </form>
+        <button onClick={createNewCategory}>Create Tag</button>
+        </>
+    )
+}

--- a/src/components/categories/CategoryList.js
+++ b/src/components/categories/CategoryList.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from "react"
+import { useHistory, Link } from "react-router-dom"
+import { deleteCategory, getCategories } from "./CategoryManager"
+
+
+export const CategoryList = () => {
+    const [categories, setCategories] = useState([])
+
+    const history = useHistory()
+
+    useEffect(() => {
+        getCategories().then(setCategories)
+    }, [])
+
+    return (
+        <>
+            <h1>Category List</h1>
+            <button onClick={() => {history.push("/categoryform")}}>Add a Tag</button>
+            {
+                categories.map((cat) => {
+                    return <>
+                        <ul>
+                            <li>
+                                {cat.label} 
+                                <button onClick={() => {history.push(`/catedit/${cat.id}`)}}>Edit</button>
+                                <button onClick={() => {deleteCategory(cat.id).then(setCategories)}}>Delete</button>
+                            </li>
+                        </ul>
+                    </>
+                })
+            }
+        </>
+    )
+}

--- a/src/components/categories/CategoryManager.js
+++ b/src/components/categories/CategoryManager.js
@@ -15,3 +15,38 @@ export const getCategory = (id) => {
     })
     .then(res => res.json())
 }
+
+export const createCategory = (newCategory) => {
+    
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`,
+            "content-Type": "application/json"
+        },
+        body: JSON.stringify(newCategory)
+    }
+    return fetch(`http://localhost:8000/categories`, fetchOptions)
+        .then(getCategories)
+
+}
+
+export const updateCategory = (category, id) => {
+    return fetch(`http://localhost:8000/categories/${id}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        },
+        body: JSON.stringify(category)
+    })
+}
+
+export const deleteCategory = (id) => {
+    return fetch (`http://localhost:8000/categories/${id}`, {
+        method: "DELETE",
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    }).then(getCategories)
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -37,7 +37,12 @@ export const NavBar = (props) => {
                     ? <li><Link to="/tags">Tag Management</Link></li>
                     : ""
             }
-                        {
+            {
+                currentUser.is_staff
+                    ? <li><Link to="/categories">Category Management</Link></li>
+                    : ""
+            }
+            {
                 currentUser.is_staff
                     ? <li><Link to="/users">User Management</Link></li>
                     : ""


### PR DESCRIPTION
# Description

added ability for admins to CRUD categories

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

login as an admin
navigate to the Categories Management  page via the navbar
click on create new category
fill out input field and click submit
that new category should be displayed on the full list
click on edit category button
change something in the input field and click save
that change should be reflected on the category list page
click delete category button 
that category should be removed from the database and erased from the DOM

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings