### PR TITLE
Jm collection detail bug

### DIFF
--- a/src/components/cardapproval/CardApprovalList.js
+++ b/src/components/cardapproval/CardApprovalList.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react"
 import { Link, useHistory } from "react-router-dom"
-import { getCards } from "../cards/CardManager"
-import { approveCard } from "../cards/CardManager"
+import { getCards, approveCard, deleteCard } from "../cards/CardManager"
 
 
 export const CardApproval = () => {
@@ -21,7 +20,10 @@ export const CardApproval = () => {
                 card.is_approved
                     ? ""
                     : <ul>
-                        <li>{card.first_name} {card.last_name} <button onClick={() => {approveCard(card.id).then(setCards)}}>Approve</button></li>
+                        <li>{card.first_name} {card.last_name} 
+                        <button onClick={() => {approveCard(card.id).then(setCards)}}>Approve</button>
+                        <button onClick={() => {deleteCard(card.id).then(setCards)}}>Deny</button>
+                        </li>
                     </ul> 
                     }
             </>

--- a/src/components/cards/CardForm.js
+++ b/src/components/cards/CardForm.js
@@ -145,6 +145,7 @@ export const CardForm = () => {
                 </div>
                 <div>
                     <button onClick={submitCardForApproval}>Submit Card</button>
+                    <button onClick={() => {history.push(`/sets/${setId}`)}}>Back</button>
                 </div>
             </section>
         </form>

--- a/src/components/cards/CardManager.js
+++ b/src/components/cards/CardManager.js
@@ -54,3 +54,12 @@ export const approveCard = (cardId) => {
         }
     }).then(getCards)
 }
+
+export const deleteCard = (id) => {
+    return fetch (`http://localhost:8000/cards/${id}`, {
+        method: "DELETE",
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("lu_token")}`
+        }
+    }).then(getCards)
+};

--- a/src/components/categories/CategoryForm.js
+++ b/src/components/categories/CategoryForm.js
@@ -32,6 +32,8 @@ export const CategoryForm = () => {
             </div>
         </form>
         <button onClick={createNewCategory}>Create Tag</button>
+        <button onClick={() => {history.push('/categories')}}>Cancel</button>
+
         </>
     )
 }

--- a/src/components/categories/CategoryList.js
+++ b/src/components/categories/CategoryList.js
@@ -15,7 +15,7 @@ export const CategoryList = () => {
     return (
         <>
             <h1>Category List</h1>
-            <button onClick={() => {history.push("/categoryform")}}>Add a Tag</button>
+            <button onClick={() => {history.push("/categoryform")}}>Add a Category</button>
             {
                 categories.map((cat) => {
                     return <>

--- a/src/components/collections/CollectionDetail.js
+++ b/src/components/collections/CollectionDetail.js
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 import { useHistory } from "react-router-dom"
 import { deleteCardCollection, getCardCollections } from "../cardcollection/CardCollectionManager"
+import { getCurrentUser } from "../users/UserManager"
 import { getSingleCollection } from "./CollectionManager"
 
 
 export const CollectionDetail = () => {
     const [collection, setCollection] = useState({})
     const [cardsInCollection, setCardsInCollection] = useState([])
+    const [currentUser, setCurrentUser] = useState({})
     const { collectionId } = useParams()
     const parsedId = parseInt(collectionId)
     const history = useHistory()
@@ -20,6 +22,10 @@ export const CollectionDetail = () => {
     useEffect(() => {
         getCardCollections().then(setCardsInCollection)
     }, [])
+
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
+    })
 
     // this function is looking to see if the card and collection in any cardcollection object exactly matches the card and collection
     // that we are looking at in the dom. We get the cardId parameter from the collection.card map below. If there is a match, the 
@@ -34,9 +40,14 @@ export const CollectionDetail = () => {
     }
 
     return <>
-        <h1>Collection Detail</h1>
+        <h1>{collection.name}</h1>
+        <h3>Owner: {collection.user?.username}</h3>
         <div>
-            <button onClick={() => {history.push('/sets')}}>Add Cards</button>
+            {
+                currentUser.id === collection.user?.id
+                    ? <button onClick={() => {history.push('/sets')}}>Add Cards</button>
+                    : ""
+            }
         </div>
         <div>
             {   // mapping over the card array in the collection object
@@ -54,10 +65,13 @@ export const CollectionDetail = () => {
                     }
                     </ul>
                     <div>
-                    <button 
-                    value={card.id}
-                    //we invoke the function onClick and pass in the card.id as the argument for cardId parameter we set above  
-                    onClick={() => {foundCardToRemove(card.id)}}>Remove Card</button>
+                    {
+                        currentUser.id === collection.user?.id
+                            ? <button 
+                              //we invoke the function onClick and pass in the card.id as the argument for cardId parameter we set above  
+                              onClick={() => {foundCardToRemove(card.id)}}>Remove Card</button>
+                            : ""
+                    }    
                     </div>
                     </>
                 })

--- a/src/components/collections/CollectionDetail.js
+++ b/src/components/collections/CollectionDetail.js
@@ -25,7 +25,7 @@ export const CollectionDetail = () => {
 
     useEffect(() => {
         getCurrentUser().then(setCurrentUser)
-    })
+    }, [])
 
     // this function is looking to see if the card and collection in any cardcollection object exactly matches the card and collection
     // that we are looking at in the dom. We get the cardId parameter from the collection.card map below. If there is a match, the 
@@ -42,6 +42,10 @@ export const CollectionDetail = () => {
     return <>
         <h1>{collection.name}</h1>
         <h3>Owner: {collection.user?.username}</h3>
+        <div>
+            <button onClick={() => {history.push(`/comments/${parsedId}`)}}>ViewCommetns</button>
+            <button onClick={() => {history.push('/allcollections')}}>Back to All Collections</button>
+        </div>
         <div>
             {
                 currentUser.id === collection.user?.id
@@ -76,9 +80,6 @@ export const CollectionDetail = () => {
                     </>
                 })
             }
-        </div>
-        <div>
-            <button onClick={() => {history.push(`/comments/${parsedId}`)}}>ViewCommetns</button>
         </div>
     </>
 }

--- a/src/components/comments/CommentForm.js
+++ b/src/components/comments/CommentForm.js
@@ -34,11 +34,12 @@ export const CommentForm = () => {
         createCollectionComments(newComment).then(history.push(`/comments/${parsedId}`))
     }
 
-    console.log(currentUser)
-
     return (
         <>
             <h1>Comment Form</h1>
+            <div>
+            <button onClick={() =>{history.push(`/comments/${parsedId}`)}}>Back to Comments</button>
+            </div>
             <label>New Comment? </label>
             <input
                 type="text"

--- a/src/components/comments/CommentList.js
+++ b/src/components/comments/CommentList.js
@@ -25,24 +25,27 @@ export const CommentList = () => {
         <>
             <h1>Comments</h1>
             <button onClick={() => { history.push(`/commentform/${parsedId}`) }}>Add Comment</button>
+            <button onClick={() => {history.push(`/collections/${parsedId}`)}}>Back to Collection</button>
             {
                 comments.map((comment) => {
                     return <>
-                        <ul>
-                            <li>{comment.content}</li>
-                            <li>Posted on: {comment.date}</li>
-                            <li>Posted by: {comment.posted_by?.username}</li>
-                        </ul>
-                        
-                        {   //only admins and creators of the comment can delete that comment
-                            currentUser.is_staff || currentUser.id === comment.posted_by?.id
-                                ? <button onClick={() => {deleteCollectionComments(comment.id).then(setComments)}}>Delete Comment</button>
-                                : ""
-                                
-                        }
-                        {   // on users who created comment can edit comment
-                            currentUser.id === comment.posted_by?.id
-                                ? <button onClick={() => {history.push(`/editcomment/${comment.id}`)}}>Edit Comment</button>
+                        {  
+                            comment.collection?.id === parseInt(parsedId)
+                                ? <ul>
+                                    <li>{comment.content}</li>
+                                    <li>Posted on: {comment.date}</li>
+                                    <li>Posted by: {comment.posted_by?.username}</li>
+                                    {   //only admins and creators of the comment can delete that comment
+                                        currentUser.is_staff || currentUser.id === comment.posted_by?.id
+                                            ? <button onClick={() => {deleteCollectionComments(comment.id).then(setComments)}}>Delete Comment</button>
+                                            : ""
+                                    }
+                                    {   // on users who created comment can edit comment
+                                        currentUser.id === comment.posted_by?.id
+                                            ? <button onClick={() => {history.push(`/editcomment/${comment.id}`)}}>Edit Comment</button>
+                                            : ""
+                                    }
+                                 </ul>
                                 : ""
                         }
                     </>

--- a/src/components/sets/SetDetail.js
+++ b/src/components/sets/SetDetail.js
@@ -3,6 +3,7 @@ import { deleteCard, getSets, getSingleSet, searchCards } from "./SetManager"
 import { getCards } from "../cards/CardManager"
 import { useHistory, Link, useParams } from "react-router-dom"
 import { getCollections } from "../collections/CollectionManager"
+import { getCurrentUser } from "../users/UserManager"
 
 
 export const SetDetail = () => {
@@ -10,6 +11,7 @@ export const SetDetail = () => {
     const [cards, setCards] = useState([])
     const [collection, setCollections] = useState([])
     const [searchTerms, setSearchTerms] = useState("")
+    const [currentUser, setCurrentUser] = useState({})
 
     const { setId } = useParams()
     const parsedId = parseInt(setId)
@@ -19,12 +21,12 @@ export const SetDetail = () => {
         getSingleSet(parsedId).then(setSet)
     }, [])
 
-    // useEffect(() => {
-    //     getCards().then(setCards)
-    // }, [])
-
     useEffect(() => {
         getCollections().then(setCollections)
+    }, [])
+
+    useEffect(() => {
+        getCurrentUser().then(setCurrentUser)
     }, [])
 
     useEffect(() => {
@@ -51,7 +53,15 @@ export const SetDetail = () => {
                             card.is_approved
                             ?
                             <ul>
-                                <li>#{card.card_number} <Link to={`/carddetail/${card.id}`}>{card.first_name} {card.last_name}</Link></li>
+                                <li>
+                                    #{card.card_number} <Link to={`/carddetail/${card.id}`}>{card.first_name} {card.last_name}</Link>
+                                    {
+                                        currentUser.is_staff
+                                            ? <button onClick={() => {deleteCard(card.id).then(setCards)}}>Delete</button>
+                                            : ""
+
+                                    }
+                                </li>
                             </ul>
                             : ""
                         }

--- a/src/components/sets/SetForm.js
+++ b/src/components/sets/SetForm.js
@@ -58,6 +58,7 @@ export const SetForm = () => {
                 </div>
                 <div>
                     <button onClick={createNewSet}>Save Set</button>
+                    <button onClick={() => {history.push('/sets')}}>Cancel</button>
                 </div>
             </form>
         </>

--- a/src/components/tags/TagForm.js
+++ b/src/components/tags/TagForm.js
@@ -32,6 +32,8 @@ export const TagForm = () => {
             </div>
         </form>
         <button onClick={createNewTag}>Create Tag</button>
+        <button onClick={() => {history.push('/tags')}}>Cancel</button>
+
         </>
     )
 }

--- a/src/components/tags/TagList.js
+++ b/src/components/tags/TagList.js
@@ -20,10 +20,10 @@ export const TagList = () => {
                 tags.map((tag) => {
                     return <>
                         <ul>
-                            <li>
+                            <li key={`${tag.id}`}>
                                 {tag.label} 
-                                <button onClick={() => {history.push(`/tagedit/${tag.id}`)}}>Edit</button>
-                                <button onClick={() => {deleteTag(tag.id).then(setTags)}}>Delete</button>
+                                <button key="1" onClick={() => {history.push(`/tagedit/${tag.id}`)}}>Edit</button>
+                                <button key="2" onClick={() => {deleteTag(tag.id).then(setTags)}}>Delete</button>
                             </li>
                         </ul>
                     </>

--- a/src/components/users/UserDetail.js
+++ b/src/components/users/UserDetail.js
@@ -29,7 +29,7 @@ export const UserDetail = () => {
                 <li>Name: {user.first_name} {user.last_name}</li>
                 <li>Email: {user.email}</li>
                 <li>Joined on: {user.date_joined}</li>
-                <li>Status: 
+                <li>Privileges: 
                     {
                         user.is_staff
                             ? " Admin"


### PR DESCRIPTION
# Description

added back buttons to most pages
fixed bugs that were causing all comments to show up on every collection
fixed bug where collectors were seeing buttons only for admins


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Collections, tags, categories, comments, should all have back buttons on their list and forms

when viewing a collections comments, only comments for that collection should be displayed

as a collector when viewing someone else's collection, you should NOT see add card or delete collection buttons displayed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings